### PR TITLE
Fix for failed job in coverage workflow

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -29,6 +29,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
+    - name: Setting up Node.JS 12.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: "12.x"
     - name: Install Node Dependencies
       run: npm install
     - name: Generate coverage report


### PR DESCRIPTION
Workflow for reporting coverage to codacy and codeclimate was missing checking out the repo and installing node.

[Failed Job](https://github.com/cse112-sp20/Quaranteam-8/actions/runs/120832120)